### PR TITLE
Clip and prevent divide by 0 in arccos

### DIFF
--- a/vtoq.py
+++ b/vtoq.py
@@ -33,7 +33,7 @@ def reduce_polygon(polygon, angle_th=0, distance_th=0):
             if d01 < distance_th and d12 < distance_th:
                 points_removed.append(i)
                 continue
-            angle = np.arccos(np.sum(v01*v12) / (d01 * d12))
+            angle = np.arccos(np.clip(np.sum(v01*v12) / (d01 * d12) if (d01 * d12) else 0, 0, 1))
             if angle < angle_th_rad:
                 points_removed.append(i)
 


### PR DESCRIPTION
I noticed when using this script that values can be very close but above 1, which are illegal values for arccos. Therefore, I suggest to clip the values. In addition, sometimes I got a division by 0 error so I simply added a check for that and return 0 when caught.